### PR TITLE
specify python2 to apk

### DIFF
--- a/gcc-base/Dockerfile
+++ b/gcc-base/Dockerfile
@@ -19,7 +19,7 @@ LABEL maintainer "Ben Baron <ben@einsteinx2.com>"
 RUN \
     # Install dependencies
     printf "Installing dependencies...\n" >&2 \
-    && apk --update add --no-cache bash build-base cmake curl git libjpeg-turbo-dev libpng-dev linux-headers musl-dev patch python subversion texinfo tree wget \
+    && apk --update add --no-cache bash build-base cmake curl git libjpeg-turbo-dev libpng-dev linux-headers musl-dev patch python2 subversion texinfo tree wget \
 	&& apk --update add --no-cache libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main \
 	&& rm -rf /var/cache/apk/* \
     && printf "Done.\n" >&2 \

--- a/kos-toolchain/Dockerfile
+++ b/kos-toolchain/Dockerfile
@@ -238,7 +238,7 @@ RUN \
     && printf "Installing useful tools for building Dreamcast projects...$NL" >&2 \
     && apk --update add --no-cache \
        bash bison bzip2 cdrkit cmake colordiff curl flex gawk git linux-headers \
-       musl-dev make patch python sed subversion tar texinfo tree vim wget &> $REDIRECT \
+       musl-dev make patch python2 sed subversion tar texinfo tree vim wget &> $REDIRECT \
 	&& apk --update add --no-cache libelf-dev --repository=http://dl-cdn.alpinelinux.org/alpine/v3.9/main \
     && rm -rf /var/cache/apk/* \
     && printf "Done.\n" >&2 \


### PR DESCRIPTION
Specify "python2" to apk per this issue:  https://github.com/docker-library/docker/issues/240

This allows the 2 docker images to be built without error.

Thanks for creating this project!